### PR TITLE
Fix memory leak: track live children with one shutdown handler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
 		'shelljob': [ base_dir + '/doc/*' ] 
 	},
 	license = 'GPLv3',
-	python_requires=">=3.6",
+	python_requires=">=3.7",
 )

--- a/src/shelljob/proc.py
+++ b/src/shelljob/proc.py
@@ -4,12 +4,63 @@
 """
 import atexit
 import multiprocessing
+import os
 import queue
 import shlex
 import subprocess
 import sys
 import threading
 import time
+
+_active_handles = set()
+_active_handles_lock = threading.Lock()
+_owner_pid = os.getpid()
+
+
+def _terminate_active_handles():
+	"""Terminate every child still running when the interpreter exits."""
+	# A forked child inherits this registry but owns none of these processes;
+	# terminating them would signal the parent's children. Testing the pid
+	# before touching the lock also avoids blocking forever on a lock that a
+	# thread which does not exist in this process held at fork time if the
+	# registered child hook ever fails to run.
+	if os.getpid() != _owner_pid:
+		return
+
+	with _active_handles_lock:
+		handles = list( _active_handles )
+
+	for handle in handles:
+		try:
+			handle.terminate()
+		except Exception:
+			pass # may have exited after the snapshot was taken
+
+
+# One stable callback for the life of the interpreter. Registering and
+# unregistering a closure per child leaves an inactive atexit registry slot
+# behind on CPython 3.10-3.13, so the churn itself grows without bound.
+atexit.register( _terminate_active_handles )
+
+
+def _reset_after_fork():
+	"""Re-arm tracking in a forked child so it can use this module itself.
+
+	The pid guard above already makes the inherited state harmless. This
+	additionally lets a forked child run its own commands and have them
+	terminated at its exit, and replaces a lock that may have been held by a
+	thread that does not exist here.
+	"""
+	global _active_handles_lock, _owner_pid
+	_active_handles.clear()
+	_active_handles_lock = threading.Lock()
+	_owner_pid = os.getpid()
+
+
+# Non-forking platforms such as Windows do not expose this Unix-only API.
+if hasattr( os, 'register_at_fork' ):
+	os.register_at_fork( after_in_child = _reset_after_fork )
+
 
 class CommandException(Exception):
 	def __init__(self,  msg ):
@@ -57,6 +108,10 @@ class Group:
 		)
 		handle.group_output_done = False
 		self.handles.append( handle )
+
+		# Track only live children; the module-level callback terminates them.
+		with _active_handles_lock:
+			_active_handles.add( handle )
 		
 		# a thread is created to do blocking-read
 		self.waiting += 1
@@ -67,25 +122,37 @@ class Group:
 			except Exception as e:
 				if on_error is not None:
 					on_error(e)
-				pass
-				
-			# To force return of any waiting read (and indicate this process is done
-			self.output.put( ( handle, None ) )
-			handle.stdout.close()
-			handle.stdin.close()
-			self.waiting -= 1
-			
+			finally:
+				# To force return of any waiting read (and indicate this process is done
+				try:
+					self.output.put( ( handle, None ) )
+				except Exception:
+					pass
+
+				# Everything here must run on every path. A skipped decrement
+				# leaves readlines() waiting forever, and a skipped discard
+				# retains the handle for the life of the interpreter.
+				for stream in ( handle.stdout, handle.stdin ):
+					try:
+						stream.close()
+					except Exception:
+						pass
+				self.waiting -= 1
+
+				# EOF on the pipe only means the child closed (or replaced) its
+				# stdout and stderr -- it may still be running. Wait for the real
+				# exit so a child that outlives its output is still terminated.
+				try:
+					handle.wait()
+				except Exception:
+					pass
+				with _active_handles_lock:
+					_active_handles.discard( handle )
+
 		block_thread = threading.Thread( target = block_read )
 		block_thread.daemon = True
 		block_thread.start()
 			
-		# kill child when parent dies
-		def premature_exit():
-			try: 
-				handle.terminate()
-			except:
-				pass # who cares why, we're exiting anyway (most likely since it is already terminated)
-		atexit.register( premature_exit )
 			
 		return handle
 		

--- a/test/test_proc_leak.py
+++ b/test/test_proc_leak.py
@@ -1,0 +1,343 @@
+"""Regression tests for the shutdown-handler leak in proc.Group (issue #14).
+
+Group._run_impl used to register an atexit handler per spawned process. The
+handler closed over the Popen handle, so the registry retained every process
+the group had ever run. Unregistering per child is not enough either: on
+CPython 3.10-3.13 atexit.unregister leaves an inactive registry slot behind,
+so the churn grows without bound. One stable callback tracking only live
+children avoids both.
+
+These tests avoid atexit._ncallbacks(): it is a private counter that does not
+decrease on unregister before 3.14. They assert the properties that matter --
+a finished child becomes collectable, runs do not churn the registry, and a
+child that outlives its output is still terminated at interpreter exit.
+"""
+import gc
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+import weakref
+
+import pytest
+
+from shelljob import proc
+
+COMMANDS = 8
+SRC = os.path.dirname( os.path.dirname( os.path.abspath( proc.__file__ ) ) )
+
+
+def _drain( group ):
+	deadline = time.time() + 10
+	while group.count_running() and time.time() < deadline:
+		group.readlines( timeout = 0.05 )
+	group.readlines( timeout = 0.05 )
+
+
+def _run_helper( program ):
+	"""Run an isolated interpreter and capture its text output."""
+	return subprocess.run( [sys.executable, '-c', program],
+		stdout = subprocess.PIPE, stderr = subprocess.PIPE,
+		universal_newlines = True, timeout = 60 )
+
+
+def test_finished_processes_become_collectable():
+	"""A finished child must be releasable, not retained for the process life."""
+	refs = []
+
+	for _ in range( COMMANDS ):
+		group = proc.Group()
+		handle = group.run( ['/bin/echo', 'regression'] )
+		refs.append( weakref.ref( handle ) )
+		_drain( group )
+		group.clear_finished()
+		del handle
+		del group
+
+	deadline = time.time() + 10
+	while time.time() < deadline:
+		gc.collect()
+		if all( r() is None for r in refs ):
+			break
+		time.sleep( 0.05 )
+	gc.collect()
+
+	leaked = sum( 1 for r in refs if r() is not None )
+	assert leaked == 0, \
+		"{} of {} finished handles still reachable; the shutdown handler " \
+		"retains them for the life of the process".format( leaked, COMMANDS )
+
+
+def test_runs_do_not_churn_the_atexit_registry( monkeypatch ):
+	"""One module-level callback must serve every invocation.
+
+	atexit.unregister does not reclaim its registry slot before CPython 3.14,
+	so registering per child leaks a slot per command even when unregistered.
+	"""
+	registrations = []
+	unregistrations = []
+	monkeypatch.setattr( proc.atexit, 'register', lambda cb: registrations.append( cb ) )
+	monkeypatch.setattr( proc.atexit, 'unregister', lambda cb: unregistrations.append( cb ) )
+
+	group = proc.Group()
+	for _ in range( COMMANDS ):
+		group.run( ['/bin/echo', 'regression'] )
+	_drain( group )
+
+	assert registrations == []
+	assert unregistrations == []
+
+
+def test_child_outliving_its_output_is_still_killed_at_exit():
+	"""EOF on the pipe does not mean the child exited.
+
+	A command that closes both stdout and stderr while still running hits EOF
+	immediately. If tracking is released there rather than at process exit, an
+	interpreter exit leaves the child orphaned. This runs a real interpreter to
+	completion and checks the child was terminated.
+	"""
+	program = textwrap.dedent( """
+		import sys, time
+		sys.path.insert( 0, {src!r} )
+		from shelljob import proc
+
+		group = proc.Group()
+		# `exec sleep` replaces the shell, so handle.pid IS the long-lived
+		# process rather than a short-lived wrapper.
+		handle = group.run( ['sh', '-c', 'exec 1>/dev/null 2>/dev/null; exec sleep 30'] )
+		deadline = time.time() + 10
+		while group.waiting > 0 and time.time() < deadline:
+			group.readlines( timeout = 0.05 )
+		print( handle.pid, flush = True )
+		""" ).format( src = SRC )
+
+	out = _run_helper( program )
+	assert out.stdout.strip(), "helper produced no pid (stderr: {})".format( out.stderr )
+	pid = int( out.stdout.strip().splitlines()[-1] )
+
+	time.sleep( 0.5 )
+	alive = True
+	try:
+		os.kill( pid, 0 )
+	except OSError:
+		alive = False
+
+	if alive: # don't leave a stray sleep behind on failure
+		try:
+			os.kill( pid, signal.SIGKILL )
+		except OSError:
+			pass
+
+	assert not alive, \
+		"child pid {} survived interpreter exit; shutdown tracking was " \
+		"released at output EOF instead of at process exit".format( pid )
+
+
+def test_forked_child_does_not_kill_the_parents_processes():
+	"""A forked worker must not inherit responsibility for the parent's children.
+
+	fork() clones only the calling thread, so a child inherits locks held by
+	threads that do not exist in it -- including each handle's internal
+	Popen._waitpid_lock, held by its reader thread for the life of the process.
+	poll() then cannot read the real status, so terminate() signals a process
+	the child does not own. The after-fork hook clears the inherited state.
+	"""
+	program = textwrap.dedent( """
+		import os, sys, time
+		sys.path.insert( 0, {src!r} )
+		from shelljob import proc
+
+		group = proc.Group()
+		handle = group.run( ['sh', '-c', 'exec 1>/dev/null 2>/dev/null; exec sleep 20'] )
+		time.sleep( 1 )
+		target = handle.pid
+		sys.stdout.flush()
+
+		pid = os.fork()
+		if pid == 0:
+			sys.exit( 0 ) # normal exit -> atexit runs in the forked child
+		os.waitpid( pid, 0 )
+		time.sleep( 1 )
+		try:
+			os.kill( target, 0 )
+			alive = True
+		except OSError:
+			alive = False
+		print( '{{}} {{}}'.format( target, alive ), flush = True )
+		try:
+			handle.kill()
+		except Exception:
+			pass
+		""" ).format( src = SRC )
+
+	out = _run_helper( program )
+	assert out.stdout.strip(), "helper produced no output (stderr: {})".format( out.stderr )
+	target, alive = out.stdout.strip().splitlines()[-1].split()
+
+	assert alive == 'True', \
+		"forked child's exit killed the parent's process {}; inherited " \
+		"handles must be dropped after fork".format( target )
+
+
+def test_handle_released_even_if_stream_close_raises():
+	"""Cleanup must not be skippable.
+
+	handle.stdin.close() can raise BrokenPipeError when the child closed its
+	input, and a caller's on_error can raise too. If either escapes before the
+	handle is discarded, it stays referenced for the life of the interpreter --
+	the leak this change exists to remove.
+	"""
+	group = proc.Group()
+	handle = group.run( ['/bin/echo', 'regression'] )
+
+	original = handle.stdin.close
+	def exploding_close():
+		original()
+		raise BrokenPipeError( 'simulated' )
+	handle.stdin.close = exploding_close
+
+	ref = weakref.ref( handle )
+	_drain( group )
+	group.clear_finished()
+	del handle
+	del group
+
+	deadline = time.time() + 10
+	while time.time() < deadline:
+		gc.collect()
+		if ref() is None:
+			break
+		time.sleep( 0.05 )
+	gc.collect()
+
+	assert ref() is None, \
+		"handle still reachable after close() raised; cleanup was skipped"
+
+
+def test_handle_released_even_if_on_error_raises( monkeypatch ):
+	"""The completion sentinel must be emitted even if on_error raises."""
+	readers = []
+
+	class DeferredThread:
+		def __init__( self, target ):
+			readers.append( target )
+			self.daemon = False
+
+		def start( self ):
+			pass
+
+	class ExplodingStream:
+		def __init__( self, stream ):
+			self.stream = stream
+
+		def readline( self ):
+			raise ValueError( 'simulated read failure' )
+
+		def close( self ):
+			self.stream.close()
+
+	def exploding_on_error( error ):
+		raise RuntimeError( 'simulated callback failure' ) from error
+
+	monkeypatch.setattr( proc.threading, 'Thread', DeferredThread )
+	group = proc.Group()
+	handle = group.run( ['/bin/echo', 'regression'], on_error = exploding_on_error )
+	handle.stdout = ExplodingStream( handle.stdout )
+
+	with pytest.raises( RuntimeError, match = 'simulated callback failure' ):
+		readers[0]()
+
+	group.readlines( timeout = 0.05 )
+	group.clear_finished()
+
+	assert handle.group_output_done
+	assert handle not in group.handles, \
+		"on_error raised before the completion sentinel; handle was retained"
+
+
+def test_pid_guard_makes_inherited_shutdown_state_inert( monkeypatch ):
+	"""The shutdown callback must ignore state owned by another process."""
+	monkeypatch.setattr( proc, '_owner_pid', proc.os.getpid() + 1 ) # pretend we are a fork
+	sentinel = []
+
+	class FakeHandle:
+		def terminate( self ):
+			sentinel.append( 'terminated' )
+
+	fake = FakeHandle()
+	proc._active_handles.add( fake )
+	try:
+		proc._terminate_active_handles()
+	finally:
+		proc._active_handles.discard( fake )
+
+	assert sentinel == [], \
+		"atexit handler terminated an inherited handle despite a pid mismatch"
+
+
+def test_import_without_register_at_fork():
+	"""Non-forking platforms such as Windows must still import the module."""
+	program = textwrap.dedent( """
+		import os, sys
+		sys.path.insert( 0, {src!r} )
+		if hasattr( os, 'register_at_fork' ):
+			del os.register_at_fork
+		from shelljob import proc
+		print( proc.Group.__name__ )
+		""" ).format( src = SRC )
+
+	out = _run_helper( program )
+	assert out.returncode == 0, \
+		"module import failed without register_at_fork (stderr: {})".format( out.stderr )
+	assert out.stdout.strip() == 'Group'
+
+
+def test_forked_child_rearms_shutdown_tracking():
+	"""The at-fork hook must reset the lock and track worker-owned commands."""
+	program = textwrap.dedent( """
+		import os, sys
+		sys.path.insert( 0, {src!r} )
+		from shelljob import proc
+
+		proc._active_handles_lock.acquire()
+		worker = os.fork()
+		if worker == 0:
+			if not proc._active_handles_lock.acquire( False ):
+				raise RuntimeError( 'at-fork hook did not replace the inherited lock' )
+			proc._active_handles_lock.release()
+
+			group = proc.Group()
+			handle = group.run(
+				['sh', '-c', 'exec 1>/dev/null 2>/dev/null; exec sleep 30'] )
+			print( handle.pid, flush = True )
+			sys.exit( 0 ) # normal exit -> the module-level atexit callback runs
+
+		proc._active_handles_lock.release()
+		os.waitpid( worker, 0 )
+		""" ).format( src = SRC )
+
+	out = _run_helper( program )
+	assert out.returncode == 0, \
+		"fork helper failed (stderr: {})".format( out.stderr )
+	assert out.stdout.strip(), \
+		"forked worker produced no child pid (stderr: {})".format( out.stderr )
+	pid = int( out.stdout.strip().splitlines()[-1] )
+
+	time.sleep( 0.5 )
+	alive = True
+	try:
+		os.kill( pid, 0 )
+	except OSError:
+		alive = False
+
+	if alive: # don't leave a stray sleep behind on failure
+		try:
+			os.kill( pid, signal.SIGKILL )
+		except OSError:
+			pass
+
+	assert not alive, \
+		"forked worker's child pid {} survived interpreter exit; the at-fork " \
+		"hook did not re-arm shutdown tracking".format( pid )


### PR DESCRIPTION
Fixes unbounded handle retention in long-running Group users. The previous implementation registered one atexit closure per child, keeping completed Popen objects reachable for the lifetime of the interpreter.

This change:

- replaces per-child callbacks with one module-level shutdown handler;
- tracks only live child handles and removes them through exception-safe cleanup after actual process exit;
- flattens reader control flow and guarantees the completion sentinel even when a caller-supplied error callback raises;
- resets inherited handles and locks after POSIX forks while preserving imports on non-forking platforms;
- retains a PID ownership guard as shutdown protection; and
- requires Python 3.7 or newer.

Regression coverage includes collectability, atexit registry churn, stream and callback failures, children outliving output, inherited handle isolation, child lock reset and re-arming, and import without register_at_fork.

Verification: 25 tests passed on CPython 3.11.16 and 3.14.7.

Closes #14
